### PR TITLE
[GGB-110] docker-compose.yml 수정

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - MYSQL_ROOT_PASSWORD=test
 
     ports:
-      - "3306:3306"
+      - "13306:3306"
     command:
       - --character-set-server=utf8mb4
       - --collation-server=utf8mb4_unicode_ci
@@ -23,6 +23,7 @@ services:
       MONGO_INITDB_DATABASE: test
     volumes:
       - mongo_data:/data/db
+
   redis:
     container_name: redis
     image: redis:alpine
@@ -31,19 +32,6 @@ services:
       - 6379:6379
     volumes:
       - redis_data:/data
-
-  springboot-app:
-    container_name: springboot
-    build:
-      context: .
-      dockerfile: Dockerfile
-    ports:
-      - "8080:8080"
-    depends_on:
-      - mysql
-      - mongo
-      - redis
-
 
 volumes:
   mysql_data:

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -5,22 +5,22 @@ spring:
   sql:
     init:
       mode: always
-      
+
   datasource:
-    url: jdbc:mysql://mysql:3306/ggbTest?useSSL=false&allowPublicKeyRetrieval=true
+    url: jdbc:mysql://localhost:13306/test?useSSL=false&allowPublicKeyRetrieval=true
     driver-class-name: com.mysql.cj.jdbc.Driver
     username: root
-    password: root
+    password: test
 
   # REDIS
   data:
     redis:
-      host: redis
+      host: localhost
       port: 6379
 
     # MONGO
     mongodb:
-      uri: mongodb://mongo:27017/test
+      uri: mongodb://localhost:27017/test
 
 # MYBATIS 설정
 mybatis:


### PR DESCRIPTION
## docker compose로 실행할 서버 관리
### AS-IS
- docker-compose 에 포함한 서버
  - mysql
  - mongodb
  - redis
  - springboot
- 문제점
  - Local에서 개발 시, 수정 사항이 발생할 때마다 gradle 이미지를 build 해줘야함.
  - 이로 인해, 실행 시마다 build가 실행되어 상대적으로 속도가 느려짐.

### TO-BE
- docker-compose에 포함한 서버
  - mysql
  - mongodb
  - redis

## port 변경
- local에서 3306으로 실행 시, 기존에 로컬에서 사용하던 db와 충돌하는 상황 발생.
- 이로 인해, 13306을 통해 접속하도록 수정.