### PR TITLE
[GGB-106] MyBatis Mapper 로직 리팩토링

### DIFF
--- a/src/main/java/com/ggb/graduationgoodbye/domain/auth/repository/TokenRepository.java
+++ b/src/main/java/com/ggb/graduationgoodbye/domain/auth/repository/TokenRepository.java
@@ -1,18 +1,33 @@
 package com.ggb.graduationgoodbye.domain.auth.repository;
 
 import com.ggb.graduationgoodbye.domain.auth.entity.Token;
-import org.apache.ibatis.annotations.Mapper;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.apache.ibatis.session.SqlSession;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
-@Mapper
-public interface TokenRepository {
+@Repository
+@RequiredArgsConstructor
+public class TokenRepository {
 
-  void save(Token token);
+  private final SqlSession mysql;
 
-  Token findToken(String refreshToken);
+  @Transactional
+  public void save(Token token) {
+    mysql.insert("TokenRepository.save", token);
+  }
 
-  Token findByUserId(String userId);
+  @Transactional
+  public void update(Token token) {
+    mysql.update("TokenRepository.update", token);
+  }
 
-  void update(Token token);
+  public Optional<Token> findToken(String refreshToken) {
+    return Optional.ofNullable(mysql.selectOne("TokenRepository.findToken", refreshToken));
+  }
 
-  int delete(Long id);
+  public Optional<Token> findByUserId(String userId) {
+    return Optional.ofNullable(mysql.selectOne("TokenRepository.findByUserId", userId));
+  }
 }

--- a/src/main/java/com/ggb/graduationgoodbye/domain/auth/service/TokenService.java
+++ b/src/main/java/com/ggb/graduationgoodbye/domain/auth/service/TokenService.java
@@ -2,8 +2,8 @@ package com.ggb.graduationgoodbye.domain.auth.service;
 
 import com.ggb.graduationgoodbye.domain.auth.dto.TokenDto;
 import com.ggb.graduationgoodbye.domain.auth.entity.Token;
+import com.ggb.graduationgoodbye.domain.auth.exception.InvalidTokenException;
 import com.ggb.graduationgoodbye.domain.member.controller.TokenReissueRequest;
-import com.ggb.graduationgoodbye.domain.auth.exception.NotExistsTokenException;
 import com.ggb.graduationgoodbye.domain.auth.exception.NotFoundTokenException;
 import com.ggb.graduationgoodbye.domain.auth.repository.TokenRepository;
 import jakarta.servlet.http.HttpServletRequest;
@@ -39,7 +39,7 @@ public class TokenService {
     String refreshToken = tokenReissueRequest.refreshToken();
 
     if (!StringUtils.hasText(refreshToken)) {
-      throw new NotExistsTokenException();
+      throw new InvalidTokenException();
     }
 
     tokenProvider.validateRefreshToken(refreshToken);

--- a/src/main/java/com/ggb/graduationgoodbye/domain/auth/service/TokenService.java
+++ b/src/main/java/com/ggb/graduationgoodbye/domain/auth/service/TokenService.java
@@ -44,8 +44,7 @@ public class TokenService {
 
     tokenProvider.validateRefreshToken(refreshToken);
 
-    Optional.ofNullable(tokenRepository.findToken(refreshToken))
-        .orElseThrow(NotFoundTokenException::new);
+    tokenRepository.findToken(refreshToken).orElseThrow(NotFoundTokenException::new);
 
     String reissuedAccessToken = reissueAccessToken(refreshToken);
     String reissuedRefreshToken = reissueRefreshToken(reissuedAccessToken);
@@ -69,17 +68,17 @@ public class TokenService {
   }
 
   private void saveOrUpdateToken(String userId, String refreshToken) {
-    Token token = tokenRepository.findByUserId(userId);
-
-    if (token == null) {
-      token = Token.builder()
+    Optional<Token> optionalToken = tokenRepository.findByUserId(userId);
+    if (optionalToken.isPresent()) {
+      Token token = optionalToken.get();
+      token.updateRefreshToken(refreshToken);
+      tokenRepository.update(token);
+    } else {
+      Token token = Token.builder()
           .userId(userId)
           .refreshToken(refreshToken)
           .build();
       tokenRepository.save(token);
-    } else {
-      token.updateRefreshToken(refreshToken);
-      tokenRepository.update(token);
     }
   }
 

--- a/src/main/java/com/ggb/graduationgoodbye/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/ggb/graduationgoodbye/domain/member/repository/MemberRepository.java
@@ -1,16 +1,28 @@
 package com.ggb.graduationgoodbye.domain.member.repository;
 
 import com.ggb.graduationgoodbye.domain.member.entity.Member;
-import org.apache.ibatis.annotations.Mapper;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.apache.ibatis.session.SqlSession;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
-@Mapper
-public interface MemberRepository {
+@Repository
+@RequiredArgsConstructor
+public class MemberRepository {
 
-  Member findById(Long id);
+  private final SqlSession mysql;
 
-  void save(Member member);
+  @Transactional
+  public void save(Member member) {
+    mysql.insert("MemberRepository.save", member);
+  }
 
-  Member findByEmail(String email);
+  public Optional<Member> findById(Long id) {
+    return Optional.ofNullable(mysql.selectOne("MemberRepository.findById", id));
+  }
 
-  boolean existsByEmail(String email);
+  public Optional<Member> findByEmail(String email) {
+    return Optional.ofNullable(mysql.selectOne("MemberRepository.findByEmail", email));
+  }
 }

--- a/src/main/java/com/ggb/graduationgoodbye/domain/member/service/MemberService.java
+++ b/src/main/java/com/ggb/graduationgoodbye/domain/member/service/MemberService.java
@@ -60,14 +60,14 @@ public class MemberService {
   }
 
   public Optional<Member> findByEmail(String email) {
-    return Optional.ofNullable(memberRepository.findByEmail(email));
-  }
-
-  public boolean existsByEmail(String email) {
-    return memberRepository.findByEmail(email) != null;
+    return memberRepository.findByEmail(email);
   }
 
   public Optional<Member> findById(Long id) {
-    return Optional.ofNullable(memberRepository.findById(id));
+    return memberRepository.findById(id);
+  }
+
+  public boolean existsByEmail(String email) {
+    return memberRepository.findByEmail(email).isPresent();
   }
 }

--- a/src/main/resources/mybatis/map/member.xml
+++ b/src/main/resources/mybatis/map/member.xml
@@ -2,8 +2,7 @@
 <!DOCTYPE mapper
   PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
   "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="com.ggb.graduationgoodbye.domain.member.repository.MemberRepository">
-
+<mapper namespace="MemberRepository">
   <select id="findById" parameterType="Long" resultType="member">
     SELECT * FROM members WHERE id = #{id};
   </select>
@@ -16,5 +15,4 @@
   <select id="findByEmail" parameterType="String" resultType="member">
     SELECT * FROM members WHERE email = #{email};
   </select>
-
 </mapper>

--- a/src/main/resources/mybatis/map/token.xml
+++ b/src/main/resources/mybatis/map/token.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE mapper
   PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
   "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="com.ggb.graduationgoodbye.domain.auth.repository.TokenRepository">
+<mapper namespace="TokenRepository">
   <insert id="save" parameterType="token" keyProperty="id">
     INSERT INTO tokens (user_id, refresh_token)
     VALUES (#{userId}, #{refreshToken});


### PR DESCRIPTION
## Mapper 로직 리팩토링
### AS-IS
- Repository Inerface와 mapper.xml 연동
- 문제점
  - Repository Interface는 MyBatis의 mapper.xml 과 매핑되어 있어서 Redis나 MongoDB같은 경우에 UserRedisRepository, UserMongoDBRepository 와 같이 새로운 Repository를 정의해줘야 함.
 
### TO-BE
- Repository를 DAO Class로 변경 한 뒤, SqlSession 의존 주입을 통해 mapper.xml과 연동
- 장점
  - UserRepository 내부에서 DB를 분기해서 처리 가능.
  - Service Layer에서 추상화 가능하며, Repository - Service Layer 간의 경계가 확실해짐.