### PR TITLE
[GGB-114] LogFilter MultipartFile 처리

### DIFF
--- a/src/main/java/com/ggb/graduationgoodbye/global/config/log/CachingRequestWrapper.java
+++ b/src/main/java/com/ggb/graduationgoodbye/global/config/log/CachingRequestWrapper.java
@@ -7,6 +7,8 @@ import jakarta.servlet.http.HttpServletRequestWrapper;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Map;
+
 import org.springframework.util.StreamUtils;
 
 public class CachingRequestWrapper extends HttpServletRequestWrapper {
@@ -15,6 +17,7 @@ public class CachingRequestWrapper extends HttpServletRequestWrapper {
 
   public CachingRequestWrapper(HttpServletRequest request) throws IOException {
     super(request);
+    Map<String, String[]> parameterMap = request.getParameterMap();
     this.cachedContent = StreamUtils.copyToByteArray(request.getInputStream());
   }
 


### PR DESCRIPTION

문제점 : multipartFile로 값을 전달 받았을 때 해당 값을 로그로 출력하지 못함.





시도 1.

LogFilter 내부에서 ContentType을 확인 후 multipartFile일 경우 예외처리

문제점 : 
 
디버그 모드로 파일 실행시 [ 지역변수 content Type을 찾을 수 없습니다. ] 오류 발생
이때문인지 contentType을 확인 후에 처리가 불가능 했음

다만, getContentType을 이용하여 String으로 Type 확인이 가능하였기에 
Type.equals(“application/json”) 와 같은 방식으로 json은 구분이 가능하였으나, multipartFile의 경우 multipart/form-data; boundary=[임의의 값] 과 같이 값이 나왔기에  처리하지 못 하였음. 

( 앞의 multipart/form-data는 고정으로 출력되기에 이를 확인하고 구분하는 방법도 존재하였지만, 비효율적이라는 생각에 패스하였음 )






다른 해결 방안 :

1. 요청의 ContentType을 구분할 수 있도록 조치



+++++++++

현재 문제는 request값을 캐싱하는 과정에서 생기는 것으로 확인됨.

request 에서 File을 getInputStream으로 읽어오는 과정에서 문제가 생기는 것으로 추정되기에 이를 읽어오기 전 getParameterMap 를 사용하여 문제를 해결하였음.

