### PR TITLE
[GGB-124] 닉네임 랜덤 생성 API 구현

### DIFF
--- a/src/main/java/com/ggb/graduationgoodbye/domain/member/business/NicknameProvider.java
+++ b/src/main/java/com/ggb/graduationgoodbye/domain/member/business/NicknameProvider.java
@@ -1,5 +1,6 @@
 package com.ggb.graduationgoodbye.domain.member.business;
 
+import com.ggb.graduationgoodbye.domain.member.common.exception.MaxNicknameCountExceededException;
 import com.ggb.graduationgoodbye.domain.member.common.exception.NotExistsRemainNicknameException;
 import java.util.HashSet;
 import java.util.Set;
@@ -17,16 +18,24 @@ public class NicknameProvider {
 
   public Set<String> provideRandomNicknames(int count) {
     Set<String> nicknames = new HashSet<>();
+    validateCount(count);
     int maxCount = count + 10;
-    while (nicknames.size() < count) {
-      if (maxCount-- < 1) {
-        throw new NotExistsRemainNicknameException();
-      }
+    for (int i = 0; i < maxCount && nicknames.size() < count; i++) {
       String nickname = nicknameGenerator.generate();
       if (!memberReader.existsByNickname(nickname)) {
         nicknames.add(nickname);
       }
     }
+
+    if (nicknames.size() < count) {
+      throw new NotExistsRemainNicknameException();
+    }
     return nicknames;
+  }
+
+  private void validateCount(int count) {
+    if (count > 100) {
+      throw new MaxNicknameCountExceededException();
+    }
   }
 }

--- a/src/main/java/com/ggb/graduationgoodbye/domain/member/business/NicknameProvider.java
+++ b/src/main/java/com/ggb/graduationgoodbye/domain/member/business/NicknameProvider.java
@@ -1,7 +1,8 @@
 package com.ggb.graduationgoodbye.domain.member.business;
 
-import java.util.ArrayList;
-import java.util.List;
+import com.ggb.graduationgoodbye.domain.member.common.exception.NotExistsRemainNicknameException;
+import java.util.HashSet;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -14,10 +15,13 @@ public class NicknameProvider {
   private final MemberReader memberReader;
   private final NicknameGenerator nicknameGenerator;
 
-  public List<String> provideRandomNicknames() {
-    ArrayList<String> nicknames = new ArrayList<>();
-    int count = 1;
+  public Set<String> provideRandomNicknames(int count) {
+    Set<String> nicknames = new HashSet<>();
+    int maxCount = count + 10;
     while (nicknames.size() < count) {
+      if (maxCount-- < 1) {
+        throw new NotExistsRemainNicknameException();
+      }
       String nickname = nicknameGenerator.generate();
       if (!memberReader.existsByNickname(nickname)) {
         nicknames.add(nickname);

--- a/src/main/java/com/ggb/graduationgoodbye/domain/member/business/NicknameProvider.java
+++ b/src/main/java/com/ggb/graduationgoodbye/domain/member/business/NicknameProvider.java
@@ -1,6 +1,7 @@
 package com.ggb.graduationgoodbye.domain.member.business;
 
 import com.ggb.graduationgoodbye.domain.member.common.exception.MaxNicknameCountExceededException;
+import com.ggb.graduationgoodbye.domain.member.common.exception.NegativeNicknameCountException;
 import com.ggb.graduationgoodbye.domain.member.common.exception.NotExistsRemainNicknameException;
 import java.util.HashSet;
 import java.util.Set;
@@ -36,6 +37,8 @@ public class NicknameProvider {
   private void validateCount(int count) {
     if (count > 100) {
       throw new MaxNicknameCountExceededException();
+    } else if (count < 0) {
+      throw new NegativeNicknameCountException();
     }
   }
 }

--- a/src/main/java/com/ggb/graduationgoodbye/domain/member/common/exception/MaxNicknameCountExceededException.java
+++ b/src/main/java/com/ggb/graduationgoodbye/domain/member/common/exception/MaxNicknameCountExceededException.java
@@ -1,0 +1,20 @@
+package com.ggb.graduationgoodbye.domain.member.common.exception;
+
+import com.ggb.graduationgoodbye.global.error.exception.BusinessException;
+import lombok.Getter;
+
+@Getter
+public class MaxNicknameCountExceededException extends BusinessException {
+
+  private final String code;
+
+  public MaxNicknameCountExceededException() {
+    this(MemberErrorType.MAX_NICKNAME_COUNT_EXCEEDED.getMessage());
+  }
+
+  public MaxNicknameCountExceededException(final String message) {
+    super(message);
+    this.code = MemberErrorType.MAX_NICKNAME_COUNT_EXCEEDED.name();
+  }
+
+}

--- a/src/main/java/com/ggb/graduationgoodbye/domain/member/common/exception/MemberErrorType.java
+++ b/src/main/java/com/ggb/graduationgoodbye/domain/member/common/exception/MemberErrorType.java
@@ -5,6 +5,8 @@ import lombok.Getter;
 @Getter
 public enum MemberErrorType {
 
+  NEGATIVE_NICKNAME_COUNT("음수를 사용할 수 없습니다."),
+
   MAX_NICKNAME_COUNT_EXCEEDED("닉네임 추천 가능 갯수를 초과했습니다."),
 
   NOT_EXISTS_REMAIN_NICKNAME("닉네임을 직접 입력 바랍니다."),

--- a/src/main/java/com/ggb/graduationgoodbye/domain/member/common/exception/MemberErrorType.java
+++ b/src/main/java/com/ggb/graduationgoodbye/domain/member/common/exception/MemberErrorType.java
@@ -5,6 +5,8 @@ import lombok.Getter;
 @Getter
 public enum MemberErrorType {
 
+  MAX_NICKNAME_COUNT_EXCEEDED("닉네임 추천 가능 갯수를 초과했습니다."),
+
   NOT_EXISTS_REMAIN_NICKNAME("닉네임을 직접 입력 바랍니다."),
 
   DUPLICATE_NICKNAME("이미 사용중인 닉네임 입니다."),

--- a/src/main/java/com/ggb/graduationgoodbye/domain/member/common/exception/MemberErrorType.java
+++ b/src/main/java/com/ggb/graduationgoodbye/domain/member/common/exception/MemberErrorType.java
@@ -5,6 +5,8 @@ import lombok.Getter;
 @Getter
 public enum MemberErrorType {
 
+  NOT_EXISTS_REMAIN_NICKNAME("닉네임을 직접 입력 바랍니다."),
+
   DUPLICATE_NICKNAME("이미 사용중인 닉네임 입니다."),
 
   INVALID_SNS_TYPE("유효하지 않은 SNS 타입입니다."),

--- a/src/main/java/com/ggb/graduationgoodbye/domain/member/common/exception/NegativeNicknameCountException.java
+++ b/src/main/java/com/ggb/graduationgoodbye/domain/member/common/exception/NegativeNicknameCountException.java
@@ -1,0 +1,19 @@
+package com.ggb.graduationgoodbye.domain.member.common.exception;
+
+import com.ggb.graduationgoodbye.global.error.exception.BusinessException;
+import lombok.Getter;
+
+@Getter
+public class NegativeNicknameCountException extends BusinessException {
+
+  private final String code;
+
+  public NegativeNicknameCountException() {
+    this(MemberErrorType.NEGATIVE_NICKNAME_COUNT.getMessage());
+  }
+
+  public NegativeNicknameCountException(final String message) {
+    super(message);
+    this.code = MemberErrorType.NEGATIVE_NICKNAME_COUNT.name();
+  }
+}

--- a/src/main/java/com/ggb/graduationgoodbye/domain/member/common/exception/NotExistsRemainNicknameException.java
+++ b/src/main/java/com/ggb/graduationgoodbye/domain/member/common/exception/NotExistsRemainNicknameException.java
@@ -1,0 +1,19 @@
+package com.ggb.graduationgoodbye.domain.member.common.exception;
+
+import com.ggb.graduationgoodbye.global.error.exception.BusinessException;
+import lombok.Getter;
+
+@Getter
+public class NotExistsRemainNicknameException extends BusinessException {
+
+  private final String code;
+
+  public NotExistsRemainNicknameException() {
+    this(MemberErrorType.NOT_EXISTS_REMAIN_NICKNAME.getMessage());
+  }
+
+  public NotExistsRemainNicknameException(final String message) {
+    super(message);
+    this.code = MemberErrorType.NOT_EXISTS_REMAIN_NICKNAME.name();
+  }
+}

--- a/src/main/java/com/ggb/graduationgoodbye/domain/member/controller/MemberController.java
+++ b/src/main/java/com/ggb/graduationgoodbye/domain/member/controller/MemberController.java
@@ -12,9 +12,8 @@ import com.ggb.graduationgoodbye.domain.member.common.dto.TokenReissueDto;
 import com.ggb.graduationgoodbye.domain.member.common.entity.Member;
 import com.ggb.graduationgoodbye.domain.member.service.MemberService;
 import com.ggb.graduationgoodbye.global.response.ApiResponse;
-import io.swagger.v3.oas.annotations.Hidden;
 import jakarta.validation.Valid;
-import java.util.List;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -117,10 +116,9 @@ public class MemberController {
   /**
    * 랜덤 닉네임 제공
    */
-  @Hidden
-  @GetMapping("/serve/nickname")
-  public ApiResponse<?> serveRandomNicknames() {
-    List<String> nicknames = memberService.serveRandomNicknames();
+  @GetMapping("/serve/nickname/{count}")
+  public ApiResponse<?> serveRandomNicknames(@PathVariable int count) {
+    Set<String> nicknames = memberService.serveRandomNicknames(count);
     return ApiResponse.ok(nicknames);
   }
 

--- a/src/main/java/com/ggb/graduationgoodbye/domain/member/controller/MemberController.java
+++ b/src/main/java/com/ggb/graduationgoodbye/domain/member/controller/MemberController.java
@@ -25,6 +25,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
@@ -116,8 +117,8 @@ public class MemberController {
   /**
    * 랜덤 닉네임 제공
    */
-  @GetMapping("/serve/nickname/{count}")
-  public ApiResponse<?> serveRandomNicknames(@PathVariable int count) {
+  @GetMapping("/serve/nickname")
+  public ApiResponse<?> serveRandomNicknames(@RequestParam int count) {
     Set<String> nicknames = memberService.serveRandomNicknames(count);
     return ApiResponse.ok(nicknames);
   }

--- a/src/main/java/com/ggb/graduationgoodbye/domain/member/service/MemberService.java
+++ b/src/main/java/com/ggb/graduationgoodbye/domain/member/service/MemberService.java
@@ -19,7 +19,7 @@ import com.ggb.graduationgoodbye.domain.member.common.dto.SnsDto;
 import com.ggb.graduationgoodbye.domain.member.common.entity.Member;
 import com.ggb.graduationgoodbye.domain.member.common.enums.SnsType;
 import com.ggb.graduationgoodbye.domain.s3.utils.S3Util;
-import java.util.List;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -126,8 +126,8 @@ public class MemberService {
   /**
    * 랜덤 닉네임 제공
    */
-  public List<String> serveRandomNicknames() {
-    return nicknameProvider.provideRandomNicknames();
+  public Set<String> serveRandomNicknames(int count) {
+    return nicknameProvider.provideRandomNicknames(count);
   }
 
   public Member getMemberOrAuthException(String snsType, String snsId, String oauthToken) {


### PR DESCRIPTION
## 구현 내용
- 닉네임 자동 생성 API 정의(/api/v1/members/serve/nickname/{count})
- 닉네임 : 형용사(20개) + 명사(50개), 1,000 개의 경우의 갯수 닉네임 생성 가능.

## 고민 사항
  - 무한루프 : maxCount로 제한
  - 최대 요청 횟수 제한 : count 최대갯수를 100개로 제한