### PR TITLE
[GGB-142] Swagger 문서화

### DIFF
--- a/src/main/java/com/ggb/graduationgoodbye/domain/commonCode/common/dto/FindMajorDto.java
+++ b/src/main/java/com/ggb/graduationgoodbye/domain/commonCode/common/dto/FindMajorDto.java
@@ -16,20 +16,24 @@ public class FindMajorDto {
    * 단일 학과 찾기 요청.
    */
   @Getter
-  @Schema(name = "FindMajorDTO_Request")
+  @Schema(name = "FindMajor_Request")
   public static class Request {
 
+    @Schema(description = "전공명")
     String name;
   }
 
   /**
    * 학과 찾기 반환.
    */
+  @Schema(name = "FindMajor_Response")
   @Getter
   @Builder
   public static class Response {
 
+    @Schema(description = "전공 아이디")
     Long id;
+    @Schema(description = "전공명")
     String major;
 
     /**

--- a/src/main/java/com/ggb/graduationgoodbye/domain/commonCode/common/dto/FindUniversityDto.java
+++ b/src/main/java/com/ggb/graduationgoodbye/domain/commonCode/common/dto/FindUniversityDto.java
@@ -16,9 +16,10 @@ public class FindUniversityDto {
    * 대학 찾기 요청.
    */
   @Getter
-  @Schema(name = "FindUniversityDto_Request")
+  @Schema(name = "FindUniversity_Request")
   public static class Request {
 
+    @Schema(description = "대학명")
     String name;
   }
 
@@ -27,10 +28,12 @@ public class FindUniversityDto {
    */
   @Getter
   @Builder
-  @Schema(name = "FindUniversityDto_Response")
+  @Schema(name = "FindUniversity_Response")
   public static class Response {
 
+    @Schema(description = "대학 아이디")
     Long id;
+    @Schema(description = "대학명")
     String university;
 
     /**

--- a/src/main/java/com/ggb/graduationgoodbye/domain/commonCode/controller/MajorApi.java
+++ b/src/main/java/com/ggb/graduationgoodbye/domain/commonCode/controller/MajorApi.java
@@ -1,0 +1,27 @@
+package com.ggb.graduationgoodbye.domain.commonCode.controller;
+
+import com.ggb.graduationgoodbye.domain.commonCode.common.dto.FindMajorDto;
+import com.ggb.graduationgoodbye.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+
+@Tag(name = "major", description = "the major API")
+public interface MajorApi {
+
+  @Operation(summary = "전체 전공 조회", tags = {"major"})
+  @ApiResponses(value = {
+      @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "전체 전공 조회 성공"),
+      @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 내부 오류")
+  })
+  ApiResponse<List<FindMajorDto.Response>> findMajorAll();
+
+  @Operation(summary = "단일 전공 조회", tags = {"major"})
+  @ApiResponses(value = {
+      @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "단일 전공 조회 성공"),
+      @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 내부 오류")
+  })
+  ApiResponse<FindMajorDto.Response> findMajor(@RequestBody FindMajorDto.Request request);
+}

--- a/src/main/java/com/ggb/graduationgoodbye/domain/commonCode/controller/MajorController.java
+++ b/src/main/java/com/ggb/graduationgoodbye/domain/commonCode/controller/MajorController.java
@@ -20,7 +20,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v1/major")
 @RequiredArgsConstructor
 @Slf4j
-public class MajorController {
+public class MajorController implements MajorApi {
 
   private final MajorService majorService;
 
@@ -28,6 +28,7 @@ public class MajorController {
   /**
    * 전체 학과 조회.
    */
+  @Override
   @GetMapping("/findMajorAll")
   public ApiResponse<List<FindMajorDto.Response>> findMajorAll() {
     List<CommonCode> majorList = majorService.findMajorAll();
@@ -39,6 +40,7 @@ public class MajorController {
   /**
    * 특정 학과 조회.
    */
+  @Override
   @PostMapping("/findMajor")
   public ApiResponse<FindMajorDto.Response> findMajor(@RequestBody FindMajorDto.Request request) {
     CommonCode major = majorService.findByMajor(request.getName());

--- a/src/main/java/com/ggb/graduationgoodbye/domain/commonCode/controller/UniversityApi.java
+++ b/src/main/java/com/ggb/graduationgoodbye/domain/commonCode/controller/UniversityApi.java
@@ -1,0 +1,29 @@
+package com.ggb.graduationgoodbye.domain.commonCode.controller;
+
+import com.ggb.graduationgoodbye.domain.commonCode.common.dto.FindUniversityDto;
+import com.ggb.graduationgoodbye.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+
+@Tag(name = "university", description = "the university API")
+public interface UniversityApi {
+
+  @Operation(summary = "전체 대학 조회", tags = {"university"})
+  @ApiResponses(value = {
+      @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "전체 대학 조회 성공"),
+      @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 내부 오류")
+  })
+  ApiResponse<List<FindUniversityDto.Response>> findUniversityAll();
+
+  @Operation(summary = "단일 대학 조회", tags = {"university"})
+  @ApiResponses(value = {
+      @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "단일 대학 조회 성공"),
+      @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 내부 오류")
+  })
+  ApiResponse<FindUniversityDto.Response> findUniversity(
+      @RequestBody FindUniversityDto.Request request);
+
+}

--- a/src/main/java/com/ggb/graduationgoodbye/domain/commonCode/controller/UniversityController.java
+++ b/src/main/java/com/ggb/graduationgoodbye/domain/commonCode/controller/UniversityController.java
@@ -21,13 +21,14 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v1/university")
 @RequiredArgsConstructor
 @Slf4j
-public class UniversityController {
+public class UniversityController implements UniversityApi {
 
   private final UniversityService universityService;
 
   /**
    * 전체 대학 조회.
    */
+  @Override
   @GetMapping("/findUniversityAll")
   public ApiResponse<List<FindUniversityDto.Response>> findUniversityAll() {
     List<CommonCode> universityList = universityService.findUniversityAll();
@@ -39,6 +40,7 @@ public class UniversityController {
   /**
    * 단일 대학 조회.
    */
+  @Override
   @PostMapping("/findUniversity")
   public ApiResponse<FindUniversityDto.Response> findUniversity(
       @RequestBody FindUniversityDto.Request request) {

--- a/src/main/java/com/ggb/graduationgoodbye/domain/member/common/dto/MemberJoinDto.java
+++ b/src/main/java/com/ggb/graduationgoodbye/domain/member/common/dto/MemberJoinDto.java
@@ -1,29 +1,40 @@
 package com.ggb.graduationgoodbye.domain.member.common.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Builder;
 import lombok.Getter;
 
 public class MemberJoinDto {
 
+  @Schema(name = "MemberJoin_Request", description = "회원가입 요청 DTO")
   @Getter
   public static class Request {
 
+    @Schema(description = "소셜토큰")
     @NotBlank(message = "oauth 토큰을 함께 요청 바랍니다.")
     private String oauthToken;
+    @Schema(description = "닉네임")
     @NotBlank(message = "닉네임을 입력 바랍니다.")
     private String nickname;
+    @Schema(description = "주소", nullable = true)
     private String address;
+    @Schema(description = "성별", nullable = true)
     private String gender;
+    @Schema(description = "나이", nullable = true)
     private Integer age;
+    @Schema(description = "연락처", nullable = true)
     private String phone;
   }
 
+  @Schema(name = "MemberJoin_Response", description = "회원가입 응답 DTO")
   @Getter
   @Builder
   public static class Response {
 
+    @Schema(description = "액세스토큰")
     private String accessToken;
+    @Schema(description = "리프레쉬토큰")
     private String refreshToken;
   }
 }

--- a/src/main/java/com/ggb/graduationgoodbye/domain/member/common/dto/MemberLoginDto.java
+++ b/src/main/java/com/ggb/graduationgoodbye/domain/member/common/dto/MemberLoginDto.java
@@ -1,23 +1,29 @@
 package com.ggb.graduationgoodbye.domain.member.common.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Builder;
 import lombok.Getter;
 
 public class MemberLoginDto {
 
+  @Schema(name = "MemberLogin_Request", description = "로그인 요청 DTO")
   @Getter
   public static class Request {
 
+    @Schema(description = "인가코드")
     @NotBlank(message = "인가코드를 입력 바랍니다.")
     private String authCode;
   }
 
+  @Schema(name = "MemberLogin_Response", description = "로그인 응답 DTO")
   @Getter
   @Builder
   public static class Response {
 
+    @Schema(description = "액세스토큰")
     private String accessToken;
+    @Schema(description = "리프레쉬토큰")
     private String refreshToken;
   }
 }

--- a/src/main/java/com/ggb/graduationgoodbye/domain/member/common/dto/PromoteArtistDto.java
+++ b/src/main/java/com/ggb/graduationgoodbye/domain/member/common/dto/PromoteArtistDto.java
@@ -1,6 +1,7 @@
 package com.ggb.graduationgoodbye.domain.member.common.dto;
 
 import com.ggb.graduationgoodbye.domain.artist.common.entity.Artist;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
 
@@ -12,25 +13,34 @@ public class PromoteArtistDto {
   /**
    * 작가 전환 요청 Request.
    */
+  @Schema(name = "PromoteArtist_Request", description = "작가 전환 요청 DTO")
   @Getter
   public static class Request {
 
+    @Schema(description = "대학교")
     private String university;
+    @Schema(description = "학과")
     private String major;
+    @Schema(description = "작가활동명")
     private String name;
   }
 
   /**
    * 작가 전환 요청 Response.
    */
+  @Schema(name = "PromoteArtist_Response", description = "작가 전환 응답 DTO")
   @Getter
   public static class Response {
 
     // member 정보도 함께 반환 필요
     // private Member member;
+    @Schema(description = "대학교")
     private String university;
+    @Schema(description = "학부")
     private String major;
+    @Schema(description = "작가활동명")
     private String name;
+    @Schema(description = "졸업증명서 URL")
     private String certificateUrl;
 
     public Response(Artist artist) {

--- a/src/main/java/com/ggb/graduationgoodbye/domain/member/common/dto/TokenReissueDto.java
+++ b/src/main/java/com/ggb/graduationgoodbye/domain/member/common/dto/TokenReissueDto.java
@@ -1,22 +1,28 @@
 package com.ggb.graduationgoodbye.domain.member.common.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Builder;
 import lombok.Getter;
 
 public class TokenReissueDto {
 
+  @Schema(name = "TokenReissue_Request", description = "액세스 토큰 재발급 요청 DTO")
   @Getter
   public static class Request {
 
+    @Schema(description = "리프레쉬 토큰")
     @NotBlank(message = "RefreshToken 을 함께 요청 바랍니다.")
     private String refreshToken;
   }
 
+  @Schema(name = "TokenReissue_Response", description = "액세스 토큰 재발급 응답 DTO")
   @Builder
   public static class Response {
 
+    @Schema(description = "액세스토큰")
     private String accessToken;
+    @Schema(description = "리프레쉬토큰")
     private String refreshToken;
   }
 }

--- a/src/main/java/com/ggb/graduationgoodbye/domain/member/common/entity/Member.java
+++ b/src/main/java/com/ggb/graduationgoodbye/domain/member/common/entity/Member.java
@@ -2,31 +2,48 @@ package com.ggb.graduationgoodbye.domain.member.common.entity;
 
 import com.ggb.graduationgoodbye.domain.member.common.enums.Role;
 import com.ggb.graduationgoodbye.domain.member.common.enums.SnsType;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.apache.ibatis.type.Alias;
 
+@Schema(name = "Member", description = "회원 Entity")
 @Alias("member")
 @Getter
 @NoArgsConstructor
 public class Member {
 
+  @Schema(description = "회원 아이디", example = "1")
   private Long id;
+  @Schema(description = "SNS 타입", example = "google")
   private SnsType snsType;
+  @Schema(description = "SNS 아이디")
   private String snsId;
+  @Schema(description = "이메일", example = "GGB@ggb.com")
   private String email;
+  @Schema(description = "사진 URL")
   private String profile;
+  @Schema(description = "닉네임", example = "amumu")
   private String nickname;
+  @Schema(description = "주소", example = "경기도 ~")
   private String address;
+  @Schema(description = "성별", example = "M/W")
   private String gender;
+  @Schema(description = "나이", example = "29")
   private Integer age;
+  @Schema(description = "연락처", example = "01012345678")
   private String phone;
+  @Schema(description = "생성자", example = "SIGNUP")
   private String createdId;
+  @Schema(description = "생성일자")
   private LocalDateTime createdAt;
+  @Schema(description = "수정자", example = "SIGNUP")
   private String updatedId;
+  @Schema(description = "수정일자")
   private LocalDateTime updatedAt;
+  @Schema(description = "권한", example = "MEMBER")
   private Role role;
 
   @Builder

--- a/src/main/java/com/ggb/graduationgoodbye/domain/member/controller/MemberApi.java
+++ b/src/main/java/com/ggb/graduationgoodbye/domain/member/controller/MemberApi.java
@@ -39,6 +39,7 @@ public interface MemberApi {
   @Operation(summary = "회원정보 조회", tags = {"member"})
   @ApiResponses(value = {
       @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "회원 정보 조회 성공"),
+      @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 실패"),
       @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 내부 오류")
   })
   ApiResponse<Member> info();
@@ -71,6 +72,7 @@ public interface MemberApi {
   @ApiResponses(value = {
       @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "작가 등업 신청 성공"),
       @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "요청 데이터 이상"),
+      @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 실패"),
       @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 내부 오류")
   })
   ApiResponse<PromoteArtistDto.Response> promoteArtist(

--- a/src/main/java/com/ggb/graduationgoodbye/domain/member/controller/MemberApi.java
+++ b/src/main/java/com/ggb/graduationgoodbye/domain/member/controller/MemberApi.java
@@ -1,0 +1,79 @@
+package com.ggb.graduationgoodbye.domain.member.controller;
+
+import com.ggb.graduationgoodbye.domain.member.common.dto.MemberJoinDto;
+import com.ggb.graduationgoodbye.domain.member.common.dto.MemberLoginDto;
+import com.ggb.graduationgoodbye.domain.member.common.dto.PromoteArtistDto;
+import com.ggb.graduationgoodbye.domain.member.common.dto.TokenReissueDto;
+import com.ggb.graduationgoodbye.domain.member.common.entity.Member;
+import com.ggb.graduationgoodbye.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.multipart.MultipartFile;
+
+@Tag(name = "member", description = "the member API")
+public interface MemberApi {
+
+  @Operation(summary = "로그인", tags = {"member"})
+  @ApiResponses(value = {
+      @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "로그인 성공"),
+      @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 내부 오류")
+  })
+  ApiResponse<MemberLoginDto.Response> login(
+      @Parameter String snsType,
+      @RequestBody MemberLoginDto.Request request);
+
+
+  @Operation(summary = "회원가입", tags = {"member"})
+  @ApiResponses(value = {
+      @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "회원가입 성공"),
+      @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "요청 데이터 이상"),
+      @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 내부 오류")
+  })
+  ApiResponse<MemberJoinDto.Response> signup(
+      @Parameter String snsType,
+      @RequestBody MemberJoinDto.Request request);
+
+  @Operation(summary = "회원정보 조회", tags = {"member"})
+  @ApiResponses(value = {
+      @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "회원 정보 조회 성공"),
+      @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 내부 오류")
+  })
+  ApiResponse<Member> info();
+
+  @Operation(summary = "액세스 토큰 재발급", tags = {"member"})
+  @ApiResponses(value = {
+      @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "액세스 토큰 재발급 성공"),
+      @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "요청 데이터 이상"),
+      @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 내부 오류")
+  })
+  ApiResponse<TokenReissueDto.Response> reissue(@RequestBody TokenReissueDto.Request request);
+
+  @Operation(summary = "닉네임 중복확인", tags = {"member"})
+  @ApiResponses(value = {
+      @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "닉네임 중복확인 성공"),
+      @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "요청 데이터 이상"),
+      @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 내부 오류")
+  })
+  ApiResponse<?> checkNickname(@Parameter String nickname);
+
+  @Operation(summary = "닉네임 랜덤 생성", tags = {"member"})
+  @ApiResponses(value = {
+      @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "닉네임 랜덤 생성 성공"),
+      @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "요청 데이터 이상"),
+      @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 내부 오류")
+  })
+  ApiResponse<?> serveRandomNicknames(@Parameter int count);
+
+  @Operation(summary = "작가 등업 신청", tags = {"member"})
+  @ApiResponses(value = {
+      @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "작가 등업 신청 성공"),
+      @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "요청 데이터 이상"),
+      @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 내부 오류")
+  })
+  ApiResponse<PromoteArtistDto.Response> promoteArtist(
+      @Parameter MultipartFile certificate,
+      @RequestBody PromoteArtistDto.Request request);
+}

--- a/src/main/java/com/ggb/graduationgoodbye/domain/member/controller/MemberController.java
+++ b/src/main/java/com/ggb/graduationgoodbye/domain/member/controller/MemberController.java
@@ -38,7 +38,7 @@ import org.springframework.web.multipart.MultipartFile;
 @RequestMapping("/api/v1/members")
 @RequiredArgsConstructor
 @Slf4j
-public class MemberController {
+public class MemberController implements MemberApi {
 
   private final OAuthUserService oAuthUserService;
   private final MemberService memberService;
@@ -47,6 +47,7 @@ public class MemberController {
   /**
    * 로그인.
    */
+  @Override
   @PostMapping("/login/{snsType}")
   public ApiResponse<MemberLoginDto.Response> login(@PathVariable("snsType") String snsType,
       @Valid @RequestBody MemberLoginDto.Request request) {
@@ -65,6 +66,7 @@ public class MemberController {
   /**
    * 회원 가입
    */
+  @Override
   @PostMapping("/signup/{snsType}")
   public ApiResponse<MemberJoinDto.Response> signup(@PathVariable String snsType,
       @Valid @RequestBody MemberJoinDto.Request request) {
@@ -81,6 +83,7 @@ public class MemberController {
   /**
    * Member 정보 반환.
    */
+  @Override
   @PreAuthorize("hasAuthority('MEMBER')")
   @GetMapping("/info")
   public ApiResponse<Member> info() {
@@ -94,6 +97,7 @@ public class MemberController {
   /**
    * Token 재발급.
    */
+  @Override
   @PostMapping("/reissue")
   public ApiResponse<TokenReissueDto.Response> reissue(
       @Valid @RequestBody TokenReissueDto.Request request) {
@@ -108,6 +112,7 @@ public class MemberController {
   /**
    * 회원 닉네임 중복 확인
    */
+  @Override
   @GetMapping("/check/nickname/{nickname}")
   public ApiResponse<?> checkNickname(@PathVariable String nickname) {
     memberService.checkNicknameExists(nickname);
@@ -117,6 +122,7 @@ public class MemberController {
   /**
    * 랜덤 닉네임 제공
    */
+  @Override
   @GetMapping("/serve/nickname")
   public ApiResponse<?> serveRandomNicknames(@RequestParam int count) {
     Set<String> nicknames = memberService.serveRandomNicknames(count);
@@ -126,16 +132,14 @@ public class MemberController {
   /**
    * 작가 등업 신청.
    */
+  @Override
   @PostMapping("promote-artist")
   @PreAuthorize("hasAuthority('MEMBER')")
   public ApiResponse<PromoteArtistDto.Response> promoteArtist(
-      @RequestPart("request") PromoteArtistDto.Request request,
-      @RequestPart("certificate") MultipartFile certificate) {
-
+      @RequestPart("certificate") MultipartFile certificate,
+      @RequestPart("request") PromoteArtistDto.Request request) {
     Artist artist = memberService.promoteArtist(request, certificate);
-
     PromoteArtistDto.Response response = new PromoteArtistDto.Response(artist);
-
     return ApiResponse.ok(response);
   }
 }

--- a/src/main/java/com/ggb/graduationgoodbye/domain/test/controller/TestApi.java
+++ b/src/main/java/com/ggb/graduationgoodbye/domain/test/controller/TestApi.java
@@ -1,0 +1,40 @@
+package com.ggb.graduationgoodbye.domain.test.controller;
+
+import com.ggb.graduationgoodbye.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import org.springframework.web.multipart.MultipartFile;
+
+@Tag(name = "test", description = "the function test API")
+public interface TestApi {
+
+  @Operation(summary = "연결 확인", tags = {"test"})
+  ApiResponse<?> check();
+
+  @Operation(summary = "예외 로그", tags = {"test"})
+  void exception(
+      @Parameter(in = ParameterIn.PATH, schema = @Schema(type = "string", allowableValues = {
+          "UNAUTHENTICATED", "FORBIDDEN", "BAD_REQUEST", "EXPIRED_TOKEN", "INVALID_TOKEN",
+          "INTERNAL_SERVER_ERROR"})
+      ) String name);
+
+  @Operation(summary = "이미지 업로드", tags = {"test"})
+  ApiResponse<?> image(
+      @Parameter MultipartFile file);
+
+  @Operation(summary = "base64 인코딩", tags = {"test"})
+  ApiResponse<?> encode(@RequestBody String data);
+
+  @Operation(summary = "base64 디코딩", tags = {"test"})
+  ApiResponse<?> decode(@RequestBody String data);
+
+  @Operation(summary = "회원 인증", tags = {"test"})
+  ApiResponse<?> authMember();
+
+  @Operation(summary = "관리자 인증", tags = {"test"})
+  ApiResponse<?> authAdmin();
+}

--- a/src/main/java/com/ggb/graduationgoodbye/domain/test/controller/TestController.java
+++ b/src/main/java/com/ggb/graduationgoodbye/domain/test/controller/TestController.java
@@ -28,25 +28,19 @@ import org.springframework.web.multipart.MultipartFile;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/test")
-public class TestController {
+public class TestController implements TestApi {
 
   private final TestService testService;
 
-  @Operation(summary = "연결 확인")
+  @Override
   @GetMapping("/check")
   public ApiResponse<?> check() {
     return ApiResponse.ok("This service is available");
   }
 
+  @Override
   @GetMapping("/exception/{name}")
-  public void exception(
-      @Parameter(
-          in = ParameterIn.PATH,
-          schema = @Schema(type = "string", allowableValues = {"UNAUTHENTICATED", "FORBIDDEN",
-              "BAD_REQUEST",
-              "EXPIRED_TOKEN", "INVALID_TOKEN", "INTERNAL_SERVER_ERROR"})
-      )
-      @PathVariable String name) {
+  public void exception(@PathVariable String name) {
     switch (name) {
       case "UNAUTHENTICATED" -> throw new UnAuthenticatedException();
       case "FORBIDDEN" -> throw new ForbiddenException();
@@ -58,24 +52,28 @@ public class TestController {
     }
   }
 
+  @Override
   @PostMapping("/image")
-  public ApiResponse<String> image(@RequestPart(value = "file") MultipartFile file) {
+  public ApiResponse<?> image(@RequestPart(value = "file") MultipartFile file) {
     String url = testService.uploadImageTest(file);
     return ApiResponse.ok(url);
   }
 
+  @Override
   @PostMapping("/base64/encode")
-  public ApiResponse<String> encode(@RequestBody String data) {
+  public ApiResponse<?> encode(@RequestBody String data) {
     String encodedData = testService.encode(data);
     return ApiResponse.ok(encodedData);
   }
 
+  @Override
   @PostMapping("/base64/decode")
-  public ApiResponse<String> decode(@RequestBody String data) {
+  public ApiResponse<?> decode(@RequestBody String data) {
     String plainText = testService.decode(data);
     return ApiResponse.ok(plainText);
   }
 
+  @Override
   @GetMapping("/auth/member")
   @PreAuthorize("hasAuthority('MEMBER')")
   public ApiResponse<?> authMember() {
@@ -88,6 +86,7 @@ public class TestController {
     return ApiResponse.ok(map);
   }
 
+  @Override
   @GetMapping("/auth/admin")
   @PreAuthorize("hasAuthority('ADMIN')")
   public ApiResponse<?> authAdmin() {

--- a/src/main/java/com/ggb/graduationgoodbye/global/config/SwaggerConfig.java
+++ b/src/main/java/com/ggb/graduationgoodbye/global/config/SwaggerConfig.java
@@ -27,9 +27,7 @@ public class SwaggerConfig {
         .addList("jwt");
 
     return new OpenAPI()
-        .components(new Components()
-            .addSecuritySchemes("jwt", jwtSecurityScheme)
-        )
+        .components(new Components().addSecuritySchemes("jwt", jwtSecurityScheme))
         .addSecurityItem(schemaRequirement)
         .info(info);
   }

--- a/src/main/java/com/ggb/graduationgoodbye/global/response/ApiResponse.java
+++ b/src/main/java/com/ggb/graduationgoodbye/global/response/ApiResponse.java
@@ -1,6 +1,7 @@
 package com.ggb.graduationgoodbye.global.response;
 
 import com.ggb.graduationgoodbye.global.error.type.ApiErrorType;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.annotation.Nonnull;
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
@@ -8,10 +9,18 @@ import org.springframework.http.HttpStatus;
 @Getter
 public class ApiResponse<T> {
 
+  @Schema(example = "OK", description = "")
+
   @Nonnull
   private final String code;
+
+  @Schema(example = "OK", description = "")
+
   @Nonnull
   private final String message;
+
+  @Schema(example = "{}", description = "")
+
   private final T data;
 
   private ApiResponse(@Nonnull String code, @Nonnull String message, T data) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,6 +12,7 @@ springdoc:
     operations-sorter: method # 메소드 별 정렬
     disable-swagger-default-url: true
     display-request-duration: true # try it out 실행 후 api 실행 시간 표시
+    doc-expansion: false
   api-docs:
     path: /api-docs
   show-actuator: false


### PR DESCRIPTION
## 구현내용
- Swagger 관련 어노테이션 API 인터페이스에 별도로 정의하여 기존 Controller 클래스와 분리.
- 각 메서드명, 요청 데이터, 응답 데이터 관련 문서화 적용.